### PR TITLE
add nanosec duration to avoid startup warning

### DIFF
--- a/MedicalDemo.xml
+++ b/MedicalDemo.xml
@@ -907,6 +907,7 @@
           <lifespan>
             <duration>
               <sec>DURATION_INFINITE_SEC</sec>
+              <nanosec>DURATION_INFINITE_NSEC</nanosec>
             </duration>
           </lifespan>
           <ownership>


### PR DESCRIPTION
Just a cleanup - without this, same 0 value is used but a WARNING is logged.  